### PR TITLE
feat: install renovate 

### DIFF
--- a/.github/workflows/renovate-pr.yml
+++ b/.github/workflows/renovate-pr.yml
@@ -1,0 +1,31 @@
+name: renovate-pr
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  create-renovate-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+            ref: dev
+      - name: Check PR
+        id: check-pr
+        run: echo "count=$(gh pr list -S 'Renovate Updates in:title' | wc -l)" >> "$GITHUB_OUTPUT"
+      - name: Create PR
+        if: steps.check-pr.outputs.count == 0
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c renovate-pr
+          git commit --allow-empty -m "Renovate Updates"
+          git push origin renovate-pr
+          gh pr create -B dev -H renovate-pr -t "Renovate Updates" -b ''

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+enable-pre-post-scripts=true
+save-exact=true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:js-app"],
+  "baseBranches": ["renovate-pr"],
+  "labels": ["dependencies"],
+  "automerge": true,
+  "platformAutomerge": true,
+  "major": {
+    "automerge": false,
+    "labels": ["dependencies", "major-upgrade"]
+  },
+  "rebaseWhen": "conflicted",
+  "timezone": "Asia/Tokyo",
+  "minimumReleaseAge": "3 days",
+  "schedule": ["after 10:30 before 18:00 every weekday except after 13:00 before 14:00"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchPackagePatterns": ["eslint"],
+      "groupName": "eslint",
+      "automerge": true
+    },
+    {
+      "matchPackagePatterns": ["^@types/"],
+      "groupName": "type definitions",
+      "automerge": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": false
+  },
+  "dependencyDashboard": false
+}


### PR DESCRIPTION
1. Please install the Renovate App.  
2. Enable the setting to automatically delete branches after merging on GitHub.

This pull request introduces a new GitHub Actions workflow for managing Renovate PRs and configures Renovate to automate dependency updates. The most important changes include adding a new workflow file and configuring Renovate settings.

GitHub Actions workflow:

* [`.github/workflows/renovate-pr.yml`](diffhunk://#diff-19332003962a9580fddb67467b2c62fb8b07e2ae4ca59ddf14ddb21cc89113bcR1-R31): Added a new workflow to create a Renovate PR when changes are pushed to the `dev` branch. This workflow checks for existing PRs with the title "Renovate Updates" and creates a new PR if none exist.

Renovate configuration:

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R1-R42): Added a new configuration file for Renovate with settings to extend the `config:js-app`, specify base branches, set labels, enable automerge for minor updates, and define package rules for dependency updates.