### PR TITLE
fix: skip corepack signature verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,11 @@
 # Base image
 FROM node:20-slim AS base
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# FIX: Bad workaround (https://github.com/nodejs/corepack/issues/612)
+ENV COREPACK_INTEGRITY_KEYS=0
+
 RUN corepack enable
 RUN apt-get update && apt-get install -y iproute2 net-tools ffmpeg
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,11 @@
 # Base image
 FROM node:20-slim AS base
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
+# FIX: Bad workaround (https://github.com/nodejs/corepack/issues/612)
+ENV COREPACK_INTEGRITY_KEYS=0
+
 RUN corepack enable
 RUN apt-get update && apt-get install -y iproute2 net-tools ffmpeg
 


### PR DESCRIPTION
Resolves nodejs/corepack#612 temporality