### PR TITLE
chore: wireit monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ app_data
 *.sln
 *.sw?
 .env
+
+# wireit states
+.wireit

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,9 +13,10 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
-    "start": "cross-env NODE_ENV=production tsx src/index.ts",
-    "build": "tsc -p tsconfig.build.json",
+    "dev": "wireit",
+    "start": "wireit",
+    "build": "wireit",
+    "type:check": "wireit",
     "auth:generate": "pnpm dlx @better-auth/cli@latest generate --config=./src/libs/auth.ts --output=./src/db/schema/auth.ts --y",
     "drizzle:generate": "drizzle-kit generate --config=drizzle.config.ts",
     "drizzle:migrate": "drizzle-kit migrate --config=drizzle.config.ts",
@@ -24,7 +25,6 @@
     "drizzle:push:local": "drizzle-kit push --config=drizzle.studio.config.ts",
     "drizzle:introspect": "drizzle-kit introspect --config=drizzle.config.ts",
     "drizzle:studio": "drizzle-kit studio --config=drizzle.studio.config.ts",
-    "type:check": "tsc --noEmit",
     "cli": "tsx src/cli.ts"
   },
   "dependencies": {
@@ -97,6 +97,33 @@
     "@types/pg": "8.11.10",
     "@types/uuid": "9.0.8",
     "typescript": "catalog:"
+  },
+  "wireit": {
+    "dev": {
+      "command": "cross-env NODE_ENV=development tsx watch src/index.ts",
+      "service": {
+        "readyWhen": {
+          "lineMatches": "Server is running on port \\d+"
+        }
+      },
+      "dependencies": ["../../packages/extensions:build"]
+    },
+    "start": {
+      "command": "cross-env NODE_ENV=production tsx src/index.ts",
+      "dependencies": ["../../packages/extensions:build"]
+    },
+    "build": {
+      "command": "tsc -p tsconfig.build.json",
+      "files": ["src", "tsconfig.json", "package.json"],
+      "output": ["dist"],
+      "dependencies": ["../../packages/extensions:build"]
+    },
+    "type:check": {
+      "command": "tsc --noEmit",
+      "files": ["src", "package.json", "tsconfig.build.json"],
+      "output": [],
+      "dependencies": ["../../packages/extensions:build"]
+    }
   },
   "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
 }

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -114,7 +114,7 @@
     },
     "build": {
       "command": "tsc -p tsconfig.build.json",
-      "files": ["src", "tsconfig.json", "package.json"],
+      "files": ["src", "tsconfig.build.json", "package.json"],
       "output": ["dist"],
       "dependencies": ["../../packages/extensions:build"]
     },

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -201,6 +201,11 @@ initSocketServer(server as HttpServer);
 
 const isDev = process.env.NODE_ENV === "development";
 
-if (isDev) showRoutes(app, { verbose: true, colorize: true });
+if (isDev) {
+	console.info(`Ready on http://localhost:${port}`);
+	console.info();
+
+	showRoutes(app, { verbose: true, colorize: true });
+}
 
 export type AppType = typeof route;

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,10 +4,10 @@
   "version": "2.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "start": "cross-env NODE_ENV=production vite preview",
-    "build": "pnpm tsc && vite build",
-    "type:check": "tsc --noEmit"
+    "dev": "wireit",
+    "start": "wireit",
+    "build": "wireit",
+    "type:check": "wireit"
   },
   "dependencies": {
     "@axe-core/playwright": "4.10.1",
@@ -102,6 +102,33 @@
     "axe-html-reporter": "2.2.11",
     "rollup-plugin-visualizer": "5.12.0",
     "typescript": "catalog:"
+  },
+  "wireit": {
+    "dev": {
+      "command": "vite",
+      "dependencies": ["../../packages/extensions:build", "../backend:build"],
+      "service": {
+        "readyWhen": {
+          "lineMatches": "Local:   http://localhost:\\d+/"
+        }
+      }
+    },
+    "build": {
+      "command": "vite build",
+      "files": ["src", "tsconfig.json", "package.json"],
+      "output": ["dist"],
+      "dependencies": ["../../packages/extensions:build", "../backend:build", "type:check"]
+    },
+    "start": {
+      "command": "cross-env NODE_ENV=production vite preview",
+      "dependencies": ["../../packages/extensions:build", "../backend:build"]
+    },
+    "type:check": {
+      "command": "tsc --noEmit",
+      "files": ["src", "package.json", "tsconfig.json"],
+      "output": [],
+      "dependencies": ["../../packages/extensions:build", "../backend:build"]
+    }
   },
   "packageManager": "pnpm@9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
 }

--- a/package.json
+++ b/package.json
@@ -44,11 +44,7 @@
       "dependencies": ["./apps/backend:dev", "./apps/frontend:dev"]
     },
     "type:check": {
-      "dependencies": [
-        "./packages/extensions:type:check",
-        "./apps/backend:type:check",
-        "./apps/frontend:type:check"
-      ]
+      "dependencies": ["./apps/backend:type:check", "./apps/frontend:type:check"]
     }
   },
   "commitlint": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "check": "biome check . --fix",
     "lint:repo": "sherif",
     "dev": "wireit",
+    "type:check": "wireit",
     "build": "pnpm -r build",
     "spell-check": "cspell lint \"**\"",
     "commit": "cz"
@@ -42,11 +43,11 @@
     "dev": {
       "dependencies": ["./apps/backend:dev", "./apps/frontend:dev"]
     },
-    "typecheck": {
+    "type:check": {
       "dependencies": [
-        "./packages/shared:typecheck",
-        "./apps/backend:typecheck",
-        "./apps/frontend:typecheck"
+        "./packages/extensions:type:check",
+        "./apps/backend:type:check",
+        "./apps/frontend:type:check"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "format": "biome format . --write",
     "check": "biome check . --fix",
     "lint:repo": "sherif",
-    "build:all": "pnpm -r build",
-    "spell": "cspell lint '**'",
+    "dev": "wireit",
+    "build": "pnpm -r build",
+    "spell-check": "cspell lint \"**\"",
     "commit": "cz"
   },
   "simple-git-hooks": {
@@ -34,7 +35,20 @@
     "sherif": "1.1.1",
     "simple-git-hooks": "2.11.1",
     "vite-tsconfig-paths": "5.0.1",
-    "vitest": "2.1.8"
+    "vitest": "2.1.8",
+    "wireit": "0.14.11"
+  },
+  "wireit": {
+    "dev": {
+      "dependencies": ["./apps/backend:dev", "./apps/frontend:dev"]
+    },
+    "typecheck": {
+      "dependencies": [
+        "./packages/shared:typecheck",
+        "./apps/backend:typecheck",
+        "./apps/frontend:typecheck"
+      ]
+    }
   },
   "commitlint": {
     "extends": ["@commitlint/config-conventional"]

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -6,6 +6,10 @@
   "exports": {
     ".": "./dist/index.js"
   },
+  "scripts": {
+    "build": "wireit",
+    "type:check": "wireit"
+  },
   "dependencies": {
     "@blockly/field-grid-dropdown": "5.0.9",
     "@blockly/field-slider": "7.0.9",
@@ -17,7 +21,16 @@
     "@types/node": "catalog:",
     "typescript": "catalog:"
   },
-  "scripts": {
-    "build": "tsc -p tsconfig.build.json"
+  "wireit": {
+    "build": {
+      "command": "tsc -p tsconfig.build.json",
+      "files": ["src", "tsconfig.json", "package.json"],
+      "output": ["dist"]
+    },
+    "type:check": {
+      "command": "tsc -p tsconfig.json --noEmit",
+      "files": ["src", "tsconfig.json", "package.json"],
+      "output": ["dist"]
+    }
   }
 }

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -24,7 +24,7 @@
   "wireit": {
     "build": {
       "command": "tsc -p tsconfig.build.json",
-      "files": ["src", "tsconfig.json", "package.json"],
+      "files": ["src", "tsconfig.build.json", "package.json"],
       "output": ["dist"]
     },
     "type:check": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       vitest:
         specifier: 2.1.8
         version: 2.1.8(@types/node@20.17.12)(jsdom@26.0.0)(terser@5.37.0)
+      wireit:
+        specifier: 0.14.11
+        version: 0.14.11
 
   apps/backend:
     dependencies:
@@ -5462,6 +5465,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@3.0.1:
+    resolution: {integrity: sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==}
+    engines: {node: '>= 16'}
+
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
 
@@ -5545,6 +5552,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@4.0.0:
+    resolution: {integrity: sha512-l/mOwLWs7BQIgOKrL46dIAbyCKvPV7YJPDspkuc88rHsZRlg3hptUGdU7Trv0VFP4d3xnSGBQrKu5ZvGB7UeIw==}
+    engines: {node: '>= 18'}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -8329,6 +8340,9 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
@@ -8721,6 +8735,10 @@ packages:
 
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -9890,6 +9908,11 @@ packages:
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
     engines: {node: '>=18'}
+
+  wireit@0.14.11:
+    resolution: {integrity: sha512-edO3AiL1wYlBIapwx8e1OGEmsG37sv7qnRzx4YDsMPcKo+6NMOjWYcfRbaeoB1MzakLrnozWB2Q1q7Ko45NckA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
@@ -15764,6 +15787,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@3.0.1: {}
+
   bare-events@2.5.4:
     optional: true
 
@@ -15875,6 +15900,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@4.0.0:
+    dependencies:
+      balanced-match: 3.0.1
 
   braces@3.0.3:
     dependencies:
@@ -19238,6 +19267,12 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@5.6.0:
     dependencies:
       xtend: 4.0.2
@@ -19758,6 +19793,8 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  retry@0.12.0: {}
 
   reusify@1.0.4: {}
 
@@ -21123,6 +21160,14 @@ snapshots:
   widest-line@5.0.0:
     dependencies:
       string-width: 7.2.0
+
+  wireit@0.14.11:
+    dependencies:
+      brace-expansion: 4.0.0
+      chokidar: 3.6.0
+      fast-glob: 3.3.2
+      jsonc-parser: 3.3.1
+      proper-lockfile: 4.1.2
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
This pull request introduces the `wireit` task runner to streamline and manage scripts across the project. The most significant changes involve updating the `package.json` files for both backend and frontend applications, as well as the root `package.json`, and corresponding updates to the `pnpm-lock.yaml` file.

### Introduction of `wireit`:

* [`apps/backend/package.json`](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aL16-R19): Replaced existing scripts for `dev`, `start`, `build`, and `type:check` with `wireit` commands. Added `wireit` configuration specifying commands and dependencies for each script. [[1]](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aL16-R19) [[2]](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aL27) [[3]](diffhunk://#diff-8d3b741039fe624dded05aa46e994d93ec459ac8d8a0cfc747f92ef447a9513aR101-R127)
* [`apps/frontend/package.json`](diffhunk://#diff-7a5fd52fecdd7d9318307d2bc348b2f3c7977dbec5fa49a9bacaaaf632737cf6L7-R10): Replaced existing scripts for `dev`, `start`, `build`, and `type:check` with `wireit` commands. Added `wireit` configuration specifying commands and dependencies for each script. [[1]](diffhunk://#diff-7a5fd52fecdd7d9318307d2bc348b2f3c7977dbec5fa49a9bacaaaf632737cf6L7-R10) [[2]](diffhunk://#diff-7a5fd52fecdd7d9318307d2bc348b2f3c7977dbec5fa49a9bacaaaf632737cf6R106-R132)
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R16): Added `wireit` configuration for `dev` and `typecheck` tasks, defining dependencies on backend and frontend tasks. Updated scripts to use `wireit` for `dev` and changed `spell` script to `spell-check`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L14-R16) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R51)

### Miscellaneous Changes:

* [`apps/backend/src/index.ts`](diffhunk://#diff-9f9b2e661dbb7c922ab7db42bebcf7f1e1d07de29477a7c6265daaa2fa6dc5eaL204-R209): Added console logs to indicate when the server is ready and to display the URL in development mode.
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR89-R91): Added `wireit` and updated various dependencies and snapshots to ensure compatibility and proper functioning with the new task runner. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR89-R91) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5468-R5471) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR5556-R5559) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8343-R8345) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR8739-R8742) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9912-R9916) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15790-R15791) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR15904-R15907) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR19270-R19275) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR19797-R19798) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR21164-R21171)