### PR TITLE
fix: add OPENAPI_DOCS_URL build argument for Docker and GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,8 @@ jobs:
         context: .
         file: ./Dockerfile
         target: frontend
+        build-args: |
+          OPENAPI_DOCS_URL=${{ env.OPENAPI_DOCS_URL }}
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/tutoriallm_frontend:latest
@@ -57,6 +59,8 @@ jobs:
         context: .
         file: ./Dockerfile
         target: backend
+        build-args: |
+          OPENAPI_DOCS_URL=${{ env.OPENAPI_DOCS_URL }}
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/tutoriallm_api:latest

--- a/.github/workflows/dev_deploy.yaml
+++ b/.github/workflows/dev_deploy.yaml
@@ -46,6 +46,8 @@ jobs:
         context: .
         file: ./Dockerfile
         target: frontend
+        build-args: |
+         OPENAPI_DOCS_URL=${{ env.OPENAPI_DOCS_URL }}
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/tutoriallm_frontend:latest-preview
@@ -57,6 +59,8 @@ jobs:
         context: .
         file: ./Dockerfile
         target: backend
+        build-args: |
+          OPENAPI_DOCS_URL=${{ env.OPENAPI_DOCS_URL }}
         push: true
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/tutoriallm_api:latest-preview

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Base image
 FROM node:20-slim AS base
 
+# Required for build /docs package
+ARG OPENAPI_DOCS_URL
+ENV OPENAPI_DOCS_URL=${OPENAPI_DOCS_URL}
+
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # FIX: Bad workaround (https://github.com/nodejs/corepack/issues/612)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,11 @@
 # Base image
 FROM node:20-slim AS base
 
+# Required for build /docs package
+ARG OPENAPI_DOCS_URL
+ENV OPENAPI_DOCS_URL=${OPENAPI_DOCS_URL}
+
+
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 # FIX: Bad workaround (https://github.com/nodejs/corepack/issues/612)

--- a/apps/docs/.env.example
+++ b/apps/docs/.env.example
@@ -1,0 +1,1 @@
+OPENAPI_DOCS_URL="https://api.tutoriallm.com/doc"


### PR DESCRIPTION
- Update Dockerfile and Dockerfile.dev to include OPENAPI_DOCS_URL build argument
- Modify GitHub Actions workflows (deploy.yaml and dev_deploy.yaml) to pass OPENAPI_DOCS_URL
- Add .env.example in docs package with default OpenAPI documentation URL